### PR TITLE
New functions to add gyms

### DIFF
--- a/commands/addgym.php
+++ b/commands/addgym.php
@@ -1,47 +1,47 @@
-<?php 
+<?php
 // Write to log.
 debug_log('ADDGYM()');
 
 // For debug.
-//debug_log($update);
-//debug_log($data);
+// debug_log($update);
+// debug_log($data);
 
 // Get gym name.
-$input = trim(substr($update['message']['text'], 4));
-list($gym_name, $lat, $lon, $address) = explode(' ', $input);
-
+$input = trim(substr($update['message']['text'], 7));
+list ($gym_name, $lat, $lon, $address) = explode(';', $input);
+$lat = str_replace(",", ".", $lat);
+$lon = str_replace(",", ".", $lon);
 // Write to log.
 debug_log('Setting gym name to ' . $gym_name);
 
 // Private chat type.
 if ($update['message']['chat']['type'] == 'private') {
-    
+
     try {
-        
+
         global $db;
-        
+
         // Build query to check if gym is already in database or not
-        $rs = my_query(
-            "
+        $rs = my_query("
         SELECT    COUNT(*)
         FROM      gyms
-          WHERE   gym_name = '{$name}'
-         "
-        );
-        
+          WHERE   gym_name = '{$gym_name}'
+         ");
+
         $row = $rs->fetch_row();
-        
+
         // Gym already in database or new
         if (empty($row['0'])) {
             // insert gym in table.
-            debug_log('Gym not found in database gym list! Inserting gym "' . $name . '" now.');
+            debug_log('Gym not found in database gym list! Inserting gym "' . $gym_name . '" now.');
             $query = '
             INSERT INTO gyms (gym_name, lat, lon, address, show_gym)
             VALUES (:gym_name, :lat, :lon, :address, 1)
         ';
+            $message = getTranslation('gym_added');
         } else {
             // Update gyms table to reflect gym changes.
-            debug_log('Gym found in database gym list! Updating gym "' . $name . '" now.');
+            debug_log('Gym found in database gym list! Updating gym "' . $gym_name . '" now.');
             $query = '
                 UPDATE        gyms
                 SET           lat = :lat,
@@ -49,23 +49,24 @@ if ($update['message']['chat']['type'] == 'private') {
                               address = :address
                 WHERE      gym_name = :gym_name
             ';
+            $message = getTranslation('gym_updated');
         }
 
-        $statement = $dbh->prepare( $query );
+        $statement = $dbh->prepare($query);
         $statement->bindValue(':gym_name', $gym_name, PDO::PARAM_STR);
         $statement->bindValue(':lat', $lat, PDO::PARAM_STR);
         $statement->bindValue(':lon', $lon, PDO::PARAM_STR);
         $statement->bindValue(':address', $address, PDO::PARAM_STR);
         $statement->execute();
-    }
-    catch (PDOException $exception) {
-        
+    } catch (PDOException $exception) {
+
         error_log($exception->getMessage());
         $dbh = null;
-        exit;
+        exit();
     }
-    
+
     // Send the message.
-    sendMessage($update['message']['chat']['id'], getTranslation('gym_name_updated'));
+    sendMessage($update['message']['chat']['id'], $message);
 }
 ?>
+        

--- a/commands/gym.php
+++ b/commands/gym.php
@@ -13,7 +13,7 @@ $gym_name = trim(substr($update['message']['text'], 4));
 debug_log('Setting gym name to ' . $gym_name);
 
 // Private chat type.
-if ($update['message']['chat']['type'] == 'private') {
+if ($update['message']['chat']['type'] == 'private' && !empty($gym_name)) {
 
     try {
      
@@ -22,14 +22,15 @@ if ($update['message']['chat']['type'] == 'private') {
             UPDATE gyms
             SET gym_name = :gym_name, show_gym = 1
             WHERE
-                id = :gym_id
+                gym_name = :gym_id
             ORDER BY
                 id DESC
             LIMIT 1
         ';
+        debug_log('gym_id ' . $update['message']['from']['id']);
         $statement = $dbh->prepare( $query );
         $statement->bindValue(':gym_name', $gym_name, PDO::PARAM_STR);
-        $statement->bindValue(':gym_id', $update['message']['from']['id'], PDO::PARAM_INT);
+        $statement->bindValue(':gym_id', '#'.$update['message']['from']['id'], PDO::PARAM_STR);
         $statement->execute();   
     }
     catch (PDOException $exception) {
@@ -41,5 +42,8 @@ if ($update['message']['chat']['type'] == 'private') {
 
     // Send the message.
     sendMessage($update['message']['chat']['id'], getTranslation('gym_name_updated'));
+}
+if(empty($gym_name)){
+    sendMessage($update['message']['chat']['id'], "Arenaname darf nicht leer sein!");
 }
 ?>

--- a/index.php
+++ b/index.php
@@ -125,6 +125,8 @@ if (isset($update['callback_query'])) {
     // Create raid and exit.
     if(RAID_VIA_LOCATION == true) {
         include_once(ROOT_PATH . '/mods/raid_by_location.php');
+    } else{
+        include_once(ROOT_PATH . '/mods/gym_by_location.php');
     }
 
 // Cleanup collection from channel/supergroup messages.

--- a/lang/language.json
+++ b/lang/language.json
@@ -388,6 +388,15 @@
     "RU":"Развернуть",
     "NO":"Flere valg",
     "FR":"Agrandir"
+  },
+  "gym_added":{
+    "DE":"Arena wurde erfolgreich hinzugefügt"
+  },
+  "gym_updatet":{
+    "DE":"Arena wurde erfolgreich aktualisiert"
+  },
+  "create_gym":{
+    "DE":"In welcher Stadt ist die Arena?"
   }
 }
 

--- a/logic.php
+++ b/logic.php
@@ -1016,13 +1016,14 @@ function raid_edit_raidlevel_keys($gym_id, $gym_first_letter)
  * Raid gym first letter selection
  * @return array
  */
-function raid_edit_gyms_first_letter_keys() {
+function raid_edit_gyms_first_letter_keys($address) {
     // Get gyms from database
     $rs = my_query(
             "
             SELECT UPPER(LEFT(gym_name, 1)) AS first_letter
             FROM      gyms
             WHERE     show_gym = 1
+            AND       address = {
             GROUP BY LEFT(gym_name, 1)
             "
         );
@@ -1048,6 +1049,46 @@ function raid_edit_gyms_first_letter_keys() {
     // Get the inline key array.
     $keys[] = $nav_keys;
 
+    return $keys;
+}
+
+
+/**
+ * Raid City selection
+ * @return array
+ */
+function raid_edit_city_keys() {
+    // Get gyms from database
+    $rs = my_query(
+        "
+            SELECT address
+            FROM      gyms
+            WHERE     show_gym = 1
+            GROUP BY LEFT(address, 1)
+            "
+        );
+    
+    // Init empty keys array.
+    $keys = [];
+    
+    while ($gym = $rs->fetch_assoc()) {
+        // Add first letter to keys array
+        $keys[] = array(
+            'text'          => $gym['address'],
+            'callback_data' => '0:raid_by_gym:' . $gym['address']
+        );
+    }
+    
+    // Get the inline key array.
+    $keys = inline_key_array($keys, 4);
+    
+    // Add back navigation key.
+    $nav_keys = [];
+    $nav_keys[] = universal_inner_key($keys, '0', 'exit', '0', getTranslation('abort'));
+    
+    // Get the inline key array.
+    $keys[] = $nav_keys;
+    
     return $keys;
 }
 
@@ -1082,6 +1123,40 @@ function raid_edit_gym_keys($first)
     // Get the inline key array.
     $keys = inline_key_array($keys, 1);
 
+    return $keys;
+}
+
+/**
+ * Raid edit gym keys.
+ * @param $first
+ * @return array
+ */
+function raid_edit_city_keys($address)
+{
+    // Get gyms from database
+    $rs = my_query(
+        "
+            SELECT    id, gym_name
+            FROM      gyms
+	    WHERE     address = '{$address}'
+            AND       show_gym = 1
+	    ORDER BY  gym_name
+            "
+    );
+    
+    // Init empty keys array.
+    $keys = [];
+    
+    while ($gym = $rs->fetch_assoc()) {
+        $keys[] = array(
+            'text'          => $gym['gym_name'],
+            'callback_data' => $first . ':edit_raidlevel:' . $gym['id']
+        );
+    }
+    
+    // Get the inline key array.
+    $keys = inline_key_array($keys, 1);
+    
     return $keys;
 }
 

--- a/mods/edit_address.php
+++ b/mods/edit_address.php
@@ -1,0 +1,57 @@
+<?php
+// Write to log.
+debug_log('edit_raidlevel()');
+
+// For debug.
+//debug_log($update);
+//debug_log($data);
+
+// Get gym data via ID in arg
+$gym_id = $data['arg'];
+$gym = get_gym($gym_id);
+
+// Back key id, action and arg
+$back_id = 0;
+$back_action = 'raid_by_gym';
+$back_arg = $data['id'];
+$gym_first_letter = $back_arg;
+
+// Get the keys.
+$keys = raid_edit_raidlevel_keys($gym_id, $gym_first_letter);
+
+// No keys found.
+if (!$keys) {
+    // Create the keys.
+    $keys = [
+        [
+            [
+                'text'          => getTranslation('abort'),
+                'callback_data' => '0:exit:0'
+            ]
+        ]
+    ];
+} else {
+    // Add navigation keys.
+    $nav_keys = [];
+    $nav_keys[] = universal_inner_key($nav_keys, $back_id, $back_action, $back_arg, getTranslation('back'));
+    $nav_keys[] = universal_inner_key($nav_keys, $gym_id, 'exit', '2', getTranslation('abort'));
+    $nav_keys = inline_key_array($nav_keys, 2);
+    // Merge keys.
+    $keys = array_merge($keys, $nav_keys);
+}
+
+// Build message.
+$msg = getTranslation('create_raid') . ': <i>' . $gym['address'] . '</i>';
+
+// Build callback message string.
+$callback_response = getTranslation('gym_saved');
+
+// Answer callback.
+answerCallbackQuery($update['callback_query']['id'], $callback_response);
+
+// Edit the message.
+edit_message($update, $msg . CR . getTranslation('select_raid_level') . ':', $keys);
+
+// Exit.
+exit();
+

--- a/mods/edit_address.php
+++ b/mods/edit_address.php
@@ -7,50 +7,30 @@ debug_log('edit_raidlevel()');
 //debug_log($data);
 
 // Get gym data via ID in arg
-$gym_id = $data['arg'];
-$gym = get_gym($gym_id);
+$city = $data['arg'];
 
 // Back key id, action and arg
 $back_id = 0;
-$back_action = 'raid_by_gym';
+$back_action = 'gym_by_location';
 $back_arg = $data['id'];
-$gym_first_letter = $back_arg;
+$gym_id = $back_arg;
 
-// Get the keys.
-$keys = raid_edit_raidlevel_keys($gym_id, $gym_first_letter);
+$rs = my_query(
+    "
+    UPDATE   gyms
+    SET      address = '$city'
+    WHERE    id = '$gym_id';
+    "
+);
 
-// No keys found.
-if (!$keys) {
-    // Create the keys.
-    $keys = [
-        [
-            [
-                'text'          => getTranslation('abort'),
-                'callback_data' => '0:exit:0'
-            ]
-        ]
-    ];
-} else {
-    // Add navigation keys.
-    $nav_keys = [];
-    $nav_keys[] = universal_inner_key($nav_keys, $back_id, $back_action, $back_arg, getTranslation('back'));
-    $nav_keys[] = universal_inner_key($nav_keys, $gym_id, 'exit', '2', getTranslation('abort'));
-    $nav_keys = inline_key_array($nav_keys, 2);
-    // Merge keys.
-    $keys = array_merge($keys, $nav_keys);
-}
-
-// Build message.
-$msg = getTranslation('create_raid') . ': <i>' . $gym['address'] . '</i>';
-
-// Build callback message string.
-$callback_response = getTranslation('gym_saved');
+$msg = 'Arena wurde angelegt. Bitte Namen eintragen mit /gym [ARENANAME]';
+$keys = [];
 
 // Answer callback.
-answerCallbackQuery($update['callback_query']['id'], $callback_response);
+answerCallbackQuery($update['callback_query']['id'], $msg);
 
 // Edit the message.
-edit_message($update, $msg . CR . getTranslation('select_raid_level') . ':', $keys);
+edit_message($update, $msg, $keys);
 
 // Exit.
 exit();

--- a/mods/gym_by_location.php
+++ b/mods/gym_by_location.php
@@ -1,0 +1,99 @@
+<?php
+// Write to log.
+debug_log('gym_by_location()');
+
+// For debug.
+//debug_log($update);
+//debug_log($data);
+
+// Get latitude / longitude values from Telegram
+if(isset($update['message']['location'])) {
+    $lat = $update['message']['location']['latitude'];
+    $lon = $update['message']['location']['longitude'];
+} else if(isset($update['callback_query'])) {
+    $lat = $data['id'];
+    $lon = $data['arg'];
+} else {
+    sendMessage($update['message']['chat']['id'], '<b>' . getTranslation('not_supported') . '</b>');
+    exit();
+}
+
+// Debug
+debug_log('Lat: ' . $lat);
+debug_log('Lon: ' . $lon);
+
+// Build address string.
+$address = getTranslation('forest');
+if(!empty(GOOGLE_API_KEY)){
+    $addr = get_address($lat, $lon);
+
+    // Get full address - Street #, ZIP District
+    $address = '';
+    $address .= (!empty($addr['street']) ? $addr['street'] : '');
+    $address .= (!empty($addr['street_number']) ? ' ' . $addr['street_number'] : '');
+    $address .= (!empty($addr) ? ', ' : '');
+    $address .= (!empty($addr['postal_code']) ? $addr['postal_code'] . ' ' : '');
+    $address .= (!empty($addr['district']) ? $addr['district'] : '');
+}
+
+// Temporary gym_name
+$gym_name = '#' . $update['message']['chat']['id'];
+$gym_letter = substr($gym_name, 0, 1);
+
+$rs = my_query(
+    "
+    INSERT INTO   gyms
+    SET           lat = '{$lat}',
+                  lon = '{$lon}',
+		  address = '{$db->real_escape_string($address)}',
+                  gym_name = '{$db->real_escape_string($gym_name)}'
+    "
+);
+
+// Get last insert id from db.
+$gym_id = my_insert_id();
+
+// Write to log.
+debug_log('Gym ID: ' . $gym_id);
+debug_log('Gym Name: ' . $gym_name);
+
+// Create the keys.
+$keys = [
+    [
+        [
+            'text'          => "Augsburg",
+            'callback_data' => $gym_id . ':edit_address:' . "Augsburg"
+        ],
+        [
+            'text'          => "Friedberg",
+            'callback_data' => $gym_id . ':edit_address:' . "Friedberg"
+        ],
+        [
+            'text'          => getTranslation('abort'),
+            'callback_data' => $gym_id . ':exit:2'
+        ]
+    ]
+];
+
+// Answer location message.
+if(isset($update['message']['location'])) {
+    // Build message.
+    $msg = getTranslation('create_raid') . ': <i>' . $address . '</i>';
+
+    // Send message.
+    send_message($update['message']['chat']['id'], $msg, $keys, ['reply_markup' => ['selective' => true, 'one_time_keyboard' => true]]);
+
+// Answer forwarded location message from geo_create.
+} else if(isset($update['callback_query'])) {
+    // Build callback message string.
+    $callback_response = getTranslation('here_we_go');
+
+    // Answer callback.
+    answerCallbackQuery($update['callback_query']['id'], $callback_response);
+
+    // Edit the message.
+    edit_message($update, getTranslation('select_gym_name'), $keys);
+}
+
+// Exit.
+exit();

--- a/mods/gym_by_location.php
+++ b/mods/gym_by_location.php
@@ -78,7 +78,7 @@ $keys = [
 // Answer location message.
 if(isset($update['message']['location'])) {
     // Build message.
-    $msg = getTranslation('create_raid') . ': <i>' . $address . '</i>';
+    $msg = getTranslation('create_gym');
 
     // Send message.
     send_message($update['message']['chat']['id'], $msg, $keys, ['reply_markup' => ['selective' => true, 'one_time_keyboard' => true]]);


### PR DESCRIPTION
- new command /addgym
-- add a gym by calling /addgym name;lat;lon;address

- new module gym_by_location
-- if raid_by_location is deactivated you can send a location to create a new gym
-- module is designed for Augsburg/Friedberg. As we don't use a GOOGLE_API_KEY you will be asked if the gym is in either Augsburg or Friedberg.

possiblie todo: 
-possibility to add new city for gym_by_location (not needed in our community at the moment)
-possibility to choose between raid and gym creation when sending a location